### PR TITLE
Fix logging write to database

### DIFF
--- a/Chapter_34/AutoLot.Dal/EfStructures/Migrations/20221121144233_UpdatedSerilogs.Designer.cs
+++ b/Chapter_34/AutoLot.Dal/EfStructures/Migrations/20221121144233_UpdatedSerilogs.Designer.cs
@@ -4,6 +4,7 @@ using AutoLot.Dal.EfStructures;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AutoLot.Dal.EfStructures.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221121144233_UpdatedSerilogs")]
+    partial class UpdatedSerilogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Chapter_34/AutoLot.Dal/EfStructures/Migrations/20221121144233_UpdatedSerilogs.cs
+++ b/Chapter_34/AutoLot.Dal/EfStructures/Migrations/20221121144233_UpdatedSerilogs.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutoLot.Dal.EfStructures.Migrations
+{
+    public partial class UpdatedSerilogs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ActionName",
+                schema: "Logging",
+                table: "SeriLogs",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FilePath",
+                schema: "Logging",
+                table: "SeriLogs",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ActionName",
+                schema: "Logging",
+                table: "SeriLogs",
+                type: "nvarchar",
+                maxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FilePath",
+                schema: "Logging",
+                table: "SeriLogs",
+                type: "nvarchar",
+                maxLength: 50);
+        }
+    }
+}


### PR DESCRIPTION
Hello. 
Logs were not written to the database. 
The reason was that the length of the columns was too small. 

_Table: 
     "Logging.SeriLogs"
Column:
     "ActionName": nvarchar(50) to nvarchar(100)
     "FilePath": nvarchar(50) to nvarchar(100)_

Attached screenshots for better understanding of the problem.
![1](https://user-images.githubusercontent.com/16943861/203084753-a7d10705-090a-4398-90a3-2250fd8239fb.png)
![2](https://user-images.githubusercontent.com/16943861/203084759-2313ddf3-e5b1-4fc6-bfb2-30fbb2789c30.png)

_**After applying the new migration, the logs began to be written to the table Logging.Serilogs**_
![3](https://user-images.githubusercontent.com/16943861/203089150-25a70c14-a313-4c75-a766-8d520fea3c9f.png)
