### PR TITLE
Here's a small bug.  LoggingConfiguration.cs

### DIFF
--- a/Chapter_31/AutoLot.Services/Logging/Configuration/LoggingConfiguration.cs
+++ b/Chapter_31/AutoLot.Services/Logging/Configuration/LoggingConfiguration.cs
@@ -60,8 +60,8 @@ public static class LoggingConfiguration
             .Enrich.WithMachineName()
             .WriteTo.File(
                 path: builder.Environment.IsDevelopment()
-                    ? settings.File.FileName
-                    : settings.File.FullLogPathAndFileName, // "ErrorLog.txt",
+                    ? settings.File.FullLogPathAndFileName 
+                    : settings.File.FileName,
                 rollingInterval: RollingInterval.Day,
                 restrictedToMinimumLevel: logLevel,
                 outputTemplate: OutputTemplate)


### PR DESCRIPTION
The settings state that the text file will be written to d:\temp\ ... if builder.Environment.IsDevelopment(). There is an error in the code and the file is saved in the project directory when it in development.