### PR TITLE
Remove hardcoded MakeId in CarTests

### DIFF
--- a/Chapter_24/AutoLot.Dal.Tests/IntegrationTests/CarTests.cs
+++ b/Chapter_24/AutoLot.Dal.Tests/IntegrationTests/CarTests.cs
@@ -397,7 +397,6 @@ public class CarTests : BaseTest, IClassFixture<EnsureAutoLotDatabaseTestFixture
             var car = new Car
             {
                 Color = "Yellow",
-                MakeId = 1,
                 PetName = "Herbie",
                 RadioNavigation = new Radio
                 {


### PR DESCRIPTION
MakeId must be make.Id, but not 1.